### PR TITLE
Typo fix in README of puppeteer

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ It also features a small but powerful framework to quickly develop custom fuzzer
 The fuzzers can work with GET/POST data, XML and JSON payloads and switch between POST and GET. Of course, fuzzers run in parallel in a multi-threaded environment.
 
 This is the very first release that uses headless chrome instead of phantomjs.
-Htcap’s Javascript crawling engine has been rewritten to take advantage of the new async/await features of ecmascript and has been converted to a nodjes module build on top of [Puppetteer](https://github.com/GoogleChrome/puppeteer).
+Htcap’s Javascript crawling engine has been rewritten to take advantage of the new async/await features of ecmascript and has been converted to a nodjes module build on top of [Puppeteer](https://github.com/GoogleChrome/puppeteer).
 
 More infos at [htcap.org](http://htcap.org).
 


### PR DESCRIPTION
Fixes the spelling of Puppeteer in the README